### PR TITLE
fix: Use correct DBT_ env prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ plugins:
         kind: boolean
         value: false
         description: Whether to skip pre-invoke hooks which automatically run dbt clean and deps
-        env: DBT_SKIP_PRE_INVOKE
+        env: DBT_EXT_SKIP_PRE_INVOKE
       - name: type
         env: DBT_EXT_TYPE
         value: postgres
@@ -143,7 +143,7 @@ plugins:
       kind: boolean
       value: false
       description: Whether to skip pre-invoke hooks which automatically run dbt clean and deps
-      env: DBT_SKIP_PRE_INVOKE
+      env: DBT_EXT_SKIP_PRE_INVOKE
     - name: type
       env: DBT_EXT_TYPE
       value: snowflake

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ plugins:
         kind: boolean
         value: false
         description: Whether to skip pre-invoke hooks which automatically run dbt clean and deps
-        env: DBT_EXT_SKIP_PRE_INVOKE
+        env: DBT_SKIP_PRE_INVOKE
       - name: type
         env: DBT_EXT_TYPE
         value: postgres
@@ -143,7 +143,7 @@ plugins:
       kind: boolean
       value: false
       description: Whether to skip pre-invoke hooks which automatically run dbt clean and deps
-      env: DBT_EXT_SKIP_PRE_INVOKE
+      env: DBT_SKIP_PRE_INVOKE
     - name: type
       env: DBT_EXT_TYPE
       value: snowflake

--- a/dbt_ext/extension.py
+++ b/dbt_ext/extension.py
@@ -59,7 +59,7 @@ class dbt(ExtensionBase):
             invoke_args: The arguments that will be passed to the command.
         """
         if self.skip_pre_invoke:
-            log.debug("skipping pre-invoke as DBT_SKIP_PRE_INVOKE is set")
+            log.debug("skipping pre-invoke as DBT_EXT_SKIP_PRE_INVOKE is set")
             return
 
         if invoke_name in ["deps", "clean"]:

--- a/dbt_ext/extension.py
+++ b/dbt_ext/extension.py
@@ -46,7 +46,7 @@ class dbt(ExtensionBase):
         )
         self.dbt_invoker = Invoker(self.dbt_bin, cwd=self.dbt_project_dir)
         self.skip_pre_invoke = (
-            os.getenv("DBT_SKIP_PRE_INVOKE", "false").lower() == "true"
+            os.getenv("DBT_EXT_SKIP_PRE_INVOKE", "false").lower() == "true"
         )
 
     def pre_invoke(self, invoke_name: str | None, *invoke_args: Any) -> None:

--- a/dbt_ext/extension.py
+++ b/dbt_ext/extension.py
@@ -40,13 +40,13 @@ class dbt(ExtensionBase):
         self.dbt_ext_type = os.getenv("DBT_EXT_TYPE", None)
         if not self.dbt_ext_type:
             raise MissingProfileTypeError("DBT_EXT_TYPE must be set")
-        self.dbt_project_dir = Path(os.getenv("DBT_EXT_PROJECT_DIR", "transform"))
+        self.dbt_project_dir = Path(os.getenv("DBT_PROJECT_DIR", "transform"))
         self.dbt_profiles_dir = Path(
-            os.getenv("DBT_EXT_PROFILES_DIR", self.dbt_project_dir / "transform")
+            os.getenv("DBT_PROFILES_DIR", self.dbt_project_dir / "transform")
         )
         self.dbt_invoker = Invoker(self.dbt_bin, cwd=self.dbt_project_dir)
         self.skip_pre_invoke = (
-            os.getenv("DBT_EXT_SKIP_PRE_INVOKE", "false").lower() == "true"
+            os.getenv("DBT_SKIP_PRE_INVOKE", "false").lower() == "true"
         )
 
     def pre_invoke(self, invoke_name: str | None, *invoke_args: Any) -> None:
@@ -59,7 +59,7 @@ class dbt(ExtensionBase):
             invoke_args: The arguments that will be passed to the command.
         """
         if self.skip_pre_invoke:
-            log.debug("skipping pre-invoke as DBT_EXT_SKIP_PRE_INVOKE is set")
+            log.debug("skipping pre-invoke as DBT_SKIP_PRE_INVOKE is set")
             return
 
         if invoke_name in ["deps", "clean"]:

--- a/dbt_ext/extension.py
+++ b/dbt_ext/extension.py
@@ -42,7 +42,7 @@ class dbt(ExtensionBase):
             raise MissingProfileTypeError("DBT_EXT_TYPE must be set")
         self.dbt_project_dir = Path(os.getenv("DBT_PROJECT_DIR", "transform"))
         self.dbt_profiles_dir = Path(
-            os.getenv("DBT_PROFILES_DIR", self.dbt_project_dir / "transform")
+            os.getenv("DBT_PROFILES_DIR", self.dbt_project_dir / "profiles")
         )
         self.dbt_invoker = Invoker(self.dbt_bin, cwd=self.dbt_project_dir)
         self.skip_pre_invoke = (


### PR DESCRIPTION
Fixes a bug that @pnadolny13 uncovered while reviewing https://github.com/meltano/hub/pull/907 where I was using the `DBT_EXT` prefix for sourcing the env vars for the `dbt` specific options, rather than `DBT_` and subsequently when that wasn't found accidentally created a profiles dir `transform` rather than `profiles`.