### PR TITLE
fix: dbt/target path in clean-targets in dbt_project.yml

### DIFF
--- a/files_dbt_ext/bundle/transform/dbt_project.yml
+++ b/files_dbt_ext/bundle/transform/dbt_project.yml
@@ -19,7 +19,6 @@ target-path: ../.meltano/transformers/dbt/target
 log-path: logs
 packages-install-path: dbt_packages
 clean-targets:
-- .meltano/transformers/dbt/target
 - dbt_packages
 - logs
 models:

--- a/files_dbt_ext/bundle/transform/dbt_project.yml
+++ b/files_dbt_ext/bundle/transform/dbt_project.yml
@@ -19,7 +19,7 @@ target-path: ../.meltano/transformers/dbt/target
 log-path: logs
 packages-install-path: dbt_packages
 clean-targets:
-- ../.meltano/transformers/dbt/target
+- .meltano/transformers/dbt/target
 - dbt_packages
 - logs
 models:


### PR DESCRIPTION
# Issue
https://github.com/meltano/meltano/issues/8391

# Summary
* Running `meltano invoke dbt-postgres:run` while following doc throws an error due to incorrect path specified in dbt_project.yml
 
# Changes made to fix the issue
* Modified the dbt_project.yml file. Removed the `../.meltano/transformers/dbt/target` path to unblock basic functionality of `dbt-postgres` like run, compile and test

