### PR TITLE
fix: Rename bigquery dbt_files/profiles/bigquery/profiles.yaml to dbt_files/profiles/bigquery/profiles.yml

### DIFF
--- a/dbt_ext/dbt_files/profiles/bigquery/profiles.yml
+++ b/dbt_ext/dbt_files/profiles/bigquery/profiles.yml
@@ -1,6 +1,3 @@
-config:
-  send_anonymous_usage_stats: False
-  use_colors: True
 meltano:
   target: "{{ env_var('MELTANO_ENVIRONMENT', 'dev') }}"
   outputs:


### PR DESCRIPTION
profiles.yaml file is not detected by default when using meltano invoke dbt-bigquery:<any command>

Renaming it to profiles.yml fixes this issue

In latest DBT versions the following has be depreciated in the profiles.yml file and same is already available in the dbt_project.yml file
config:
  send_anonymous_usage_stats: False
  use_colors: True

after removing above section fixes the issue
