### PR TITLE
Keep default dbt target path

### DIFF
--- a/dbt_ext/dbt_files/bundle/transform/dbt_project.yml
+++ b/dbt_ext/dbt_files/bundle/transform/dbt_project.yml
@@ -18,11 +18,11 @@ macro-paths:
 - macros
 snapshot-paths:
 - snapshots
-target-path: ../.meltano/transformers/dbt/target
+target-path: target
 log-path: logs
 packages-install-path: dbt_packages
 clean-targets:
-- ../.meltano/transformers/dbt/target
+- target
 - dbt_packages
 - logs
 models:


### PR DESCRIPTION
As of version 1.7 (November 2023), a target-path outside of the dbt project's folder structure is disallowed, see https://github.com/dbt-labs/dbt-core/issues/8318.