### PR TITLE
fix: remove empty models config from dbt_project.yml template

### DIFF
--- a/dbt_ext/dbt_files/bundle/transform/dbt_project.yml
+++ b/dbt_ext/dbt_files/bundle/transform/dbt_project.yml
@@ -25,5 +25,3 @@ clean-targets:
 - target
 - dbt_packages
 - logs
-models:
-  my_meltano_project: null


### PR DESCRIPTION
## Summary

- Removes the `models: {my_meltano_project: null}` entry from the bundled `dbt_project.yml` template
- This entry was triggering `CustomKeyInConfigDeprecation` warnings in dbt 1.10+ on every dbt command (`clean`, `deps`, `run`, etc.)
- No functional change — the section provided no actual model configuration

## Links

- https://docs.getdbt.com/reference/deprecations?version=1.10#customkeyinconfigdeprecation

## Test plan

- [ ] Confirm integration test no longer emits `CustomKeyInConfigDeprecation` / `DeprecationsSummary` warnings in CI output