### PR TITLE
feat: add dbt-clickhouse profile support

### DIFF
--- a/dbt_ext/dbt_files/profiles/clickhouse/profiles.yml
+++ b/dbt_ext/dbt_files/profiles/clickhouse/profiles.yml
@@ -1,0 +1,37 @@
+# ClickHouse config reference: https://github.com/ClickHouse/dbt-clickhouse
+meltano:
+  target: "{{ env_var('MELTANO_ENVIRONMENT', 'dev') }}"
+  outputs:
+    dev:
+      type: clickhouse
+      host: "{{ env_var('DBT_CLICKHOUSE_HOST') }}"
+      port: "{{ env_var('DBT_CLICKHOUSE_PORT') | int }}"
+      user: "{{ env_var('DBT_CLICKHOUSE_USER') }}"
+      password: "{{ env_var('DBT_CLICKHOUSE_PASSWORD') }}"
+      schema: "{{ env_var('DBT_CLICKHOUSE_SCHEMA') }}"
+      threads: 2
+      connect_timeout: 10
+      send_receive_timeout: 300
+      retries: 1
+    staging:
+      type: clickhouse
+      host: "{{ env_var('DBT_CLICKHOUSE_HOST') }}"
+      port: "{{ env_var('DBT_CLICKHOUSE_PORT') | int }}"
+      user: "{{ env_var('DBT_CLICKHOUSE_USER') }}"
+      password: "{{ env_var('DBT_CLICKHOUSE_PASSWORD') }}"
+      schema: "{{ env_var('DBT_CLICKHOUSE_SCHEMA') }}"
+      threads: 4
+      connect_timeout: 10
+      send_receive_timeout: 300
+      retries: 1
+    prod:
+      type: clickhouse
+      host: "{{ env_var('DBT_CLICKHOUSE_HOST') }}"
+      port: "{{ env_var('DBT_CLICKHOUSE_PORT') | int }}"
+      user: "{{ env_var('DBT_CLICKHOUSE_USER') }}"
+      password: "{{ env_var('DBT_CLICKHOUSE_PASSWORD') }}"
+      schema: "{{ env_var('DBT_CLICKHOUSE_SCHEMA') }}"
+      threads: 6
+      connect_timeout: 10
+      send_receive_timeout: 300
+      retries: 1


### PR DESCRIPTION
Added profiles.yml for ClickHouse adapter (ClickHouse/dbt-clickhouse) to enable dbt-clickhouse support in meltano.

The profile covers dev, staging, and prod environments with configurable connection settings via environment variables:

- DBT_CLICKHOUSE_HOST
- DBT_CLICKHOUSE_PORT
- DBT_CLICKHOUSE_USER
- DBT_CLICKHOUSE_PASSWORD
- DBT_CLICKHOUSE_SCHEMA

No application logic changes required; the extension's initialize() method dynamically deploys any matching profile type from the profiles/ directory at runtime.

Closes #87